### PR TITLE
Fix comparison of unsigned expression < 0 is always false.

### DIFF
--- a/src/nautilus-dropbox-hooks.c
+++ b/src/nautilus-dropbox-hooks.c
@@ -158,7 +158,7 @@ try_to_connect(NautilusDropboxHookserv *hookserv) {
   
   /* set native non-blocking, for connect timeout */
   {
-    unsigned int flags;
+    int flags;
 
     if ((flags = fcntl(hookserv->socket, F_GETFL, 0)) < 0) {
       goto FAIL_CLEANUP;


### PR DESCRIPTION
	int fcntl(int fd, int cmd, ... /* arg */ );