### PR TITLE
Explicitly load using python2 interpreter

### DIFF
--- a/dropbox.in
+++ b/dropbox.in
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 #
 # Copyright (c) Dropbox, Inc.
 #


### PR DESCRIPTION
Prevents dropbox startup crash on systems where 'python' is a link to 'python3'