### PR TITLE
Fix adding dropbox.list into aptdir on ubuntu cosmic

### DIFF
--- a/generate-deb.sh
+++ b/generate-deb.sh
@@ -227,7 +227,7 @@ KEYDATA
             APTDIR=$(apt_config_val Dir)
             APTETC=$(apt_config_val 'Dir::Etc')
             APT_SOURCES="$APTDIR$APTETC$(apt_config_val 'Dir::Etc::sourcelist')"
-            APT_SOURCESDIR="$APTDIR$APTETC$(apt_config_val 'Dir::Etc::sourceparts')"
+            APT_SOURCESDIR="$APTDIR$APTETC$/(apt_config_val 'Dir::Etc::sourceparts')"
           }
 
           # Add the Dropbox repository to the apt sources.

--- a/generate-deb.sh
+++ b/generate-deb.sh
@@ -226,8 +226,7 @@ KEYDATA
           find_apt_sources() {
             APTDIR=$(apt_config_val Dir)
             APTETC=$(apt_config_val 'Dir::Etc')
-            APT_SOURCES="$APTDIR$APTETC$(apt_config_val 'Dir::Etc::sourcelist')"
-            APT_SOURCESDIR="$APTDIR$APTETC$/(apt_config_val 'Dir::Etc::sourceparts')"
+            APT_SOURCESDIR="$APTDIR$APTETC/$(apt_config_val 'Dir::Etc::sourceparts')"
           }
 
           # Add the Dropbox repository to the apt sources.
@@ -380,8 +379,7 @@ uninstall_key() {
 find_apt_sources() {
   APTDIR=$(apt_config_val Dir)
   APTETC=$(apt_config_val 'Dir::Etc')
-  APT_SOURCES="$APTDIR$APTETC$(apt_config_val 'Dir::Etc::sourcelist')"
-  APT_SOURCESDIR="$APTDIR$APTETC$(apt_config_val 'Dir::Etc::sourceparts')"
+  APT_SOURCESDIR="$APTDIR$APTETC/$(apt_config_val 'Dir::Etc::sourceparts')"
 }
 
 # Remove a repository from the apt sources.


### PR DESCRIPTION
The installation process doesn't create dropbox.list file under the aptdir on On Ubuntu 18 which causes apt-get commands cannot lookup dropbox.
It's because `apt-config Dir::Etc` on Ubuntu 18 doesn’t have `/` at the end.

Expected: `Dir::Etc "etc/apt/";`
On Ubuntu 18: `Dir::Etc "etc/apt";`

So it ends up with `APT_SOURCESDIR="$APTDIR$APTETC$(apt_config_val 'Dir::Etc::sourceparts')"` returning `/etc/aptsources.list.d/` instead of  `/etc/apt/sources.list.d/` on Ubuntu 18.

Fix it by adding `/` at the end of the `Dir::Etc` value. It will cause returning `/etc/apt//sources.list.d/` on other systems which is not harm.