### PR TITLE
Cherry-pick Ubuntu patches to correctly start with Unity and Budgie:

### DIFF
--- a/dropbox.in
+++ b/dropbox.in
@@ -750,9 +750,18 @@ def requires_dropbox_running(meth):
 def start_dropbox():
     if os.access(DROPBOXD_PATH, os.X_OK):
         f = open("/dev/null", "w")
+
+        # Fix indicator icon and menu on Unity environments. (LP: #1559249)
+        # Fix indicator icon and menu in Budgie environment. (LP: #1683051)
+        new_env = os.environ.copy()        
+        current_env = os.environ.get("XDG_CURRENT_DESKTOP", '').split(":")
+        to_check = ['Unity', 'Budgie']
+        if any(word in to_check for word in current_env):
+            new_env['XDG_CURRENT_DESKTOP'] = 'Unity'
+
         # we don't reap the child because we're gonna die anyway, let init do it
         subprocess.Popen([DROPBOXD_PATH], preexec_fn=os.setsid, cwd=os.path.expanduser("~"),
-                             stderr=sys.stderr, stdout=f, close_fds=True)
+                             stderr=sys.stderr, stdout=f, close_fds=True, env=new_env)
 
         # in seconds
         interval = 0.5


### PR DESCRIPTION
 This works around broken dropbox binary that will only activate the
 indicator icon and menu on Ubuntu Unity < 16.10. This patch coerces
 XDG_CURRENT_DESKTOP to report as "Unity" following the recent change
 to "Unity7"
Author: Martin Wimpress <martin.wimpress@ubuntu.com>
Bug-Ubuntu: https://bugs.launchpad.net/bugs/1559249

Description: Coerce XDG_CURRENT_DESKTOP to "Unity". (LP: #1683051)
Abstract:
 This works around broken dropbox binary that will only activate the
 indicator icon and menu on Ubuntu Unity < 16.10. This patch coerces
 XDG_CURRENT_DESKTOP to report as "Unity" for the budgie-desktop
Author: David Mohammed <fossfreedom@ubuntu.com>
Bug-Ubuntu: https://bugs.launchpad.net/bugs/1683051