### PR TITLE
Stop the ticker if the script is being run without a tty.

### DIFF
--- a/dropbox.in
+++ b/dropbox.in
@@ -663,9 +663,10 @@ class DropboxCommand(object):
 
         self.f.flush()
 
-        # Start a ticker
-        ticker_thread = CommandTicker()
-        ticker_thread.start()
+        if sys.stderr.isatty():
+            # Start a ticker
+            ticker_thread = CommandTicker()
+            ticker_thread.start()
 
         # This is the potentially long-running call.
         try:
@@ -673,9 +674,10 @@ class DropboxCommand(object):
         except KeyboardInterrupt:
             raise DropboxCommand.BadConnectionError("Keyboard interruption detected")
         finally:
-            # Tell the ticker to stop.
-            ticker_thread.stop()
-            ticker_thread.join()
+            if sys.stderr.isatty():
+                # Tell the ticker to stop.
+                ticker_thread.stop()
+                ticker_thread.join()
 
         if ok:
             toret = {}

--- a/dropbox.in
+++ b/dropbox.in
@@ -663,6 +663,7 @@ class DropboxCommand(object):
 
         self.f.flush()
 
+        ticker_thread = None
         if sys.stderr.isatty():
             # Start a ticker
             ticker_thread = CommandTicker()
@@ -674,7 +675,7 @@ class DropboxCommand(object):
         except KeyboardInterrupt:
             raise DropboxCommand.BadConnectionError("Keyboard interruption detected")
         finally:
-            if sys.stderr.isatty():
+            if ticker_thread is not None:
                 # Tell the ticker to stop.
                 ticker_thread.stop()
                 ticker_thread.join()


### PR DESCRIPTION
At present the ticker can create output when it is being run without a tty.  This creates messy and unusuable output for scripts, emails, etc.  This change is a simple suggestion of how to clean this up.