### PR TITLE
Catch previously uncaught exception

### DIFF
--- a/dropbox.in
+++ b/dropbox.in
@@ -1316,7 +1316,10 @@ options:
         console_print(lansync.__doc__,linebreak=False)
     else:
         with closing(DropboxCommand()) as dc:
-            dc.set_lan_sync(lansync='enabled' if should_lansync else 'disabled')
+            try:
+                dc.set_lan_sync(lansync='enabled' if should_lansync else 'disabled')
+            except DropboxCommand.BadConnectionError:
+                console_print("Dropbox isn't responding!")
 
 
 @command


### PR DESCRIPTION
There is an exception being thrown that is not currently caught in the code. Under high resource usage I can receive the following exception. I've made a fix that resolves this. I've tried to keep the fix inline with existing handling within the codebase.

Example stack trace below.  Line numbers may not match entirely due to local edits.

```
Traceback (most recent call last):
  File "/usr/local/bin/dropbox", line 646, in __readline
    toret = self.f.readline().rstrip("\n")
  File "/usr/lib64/python3.7/socket.py", line 589, in readinto
    return self._sock.recv_into(b)
socket.timeout: timed out

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/dropbox", line 1597, in <module>
    ret = main(sys.argv)
  File "/usr/local/bin/dropbox", line 1586, in main
    result = commands[argv[i]](argv[i+1:])
  File "/usr/local/bin/dropbox", line 746, in newmeth
    return meth(*n, **kw)
  File "/usr/local/bin/dropbox", line 1310, in lansync
    dc.set_lan_sync(lansync='enabled' if should_lansync else 'disabled')
  File "/usr/local/bin/dropbox", line 717, in __spec_command
    return self.send_command(str(name), kw)
  File "/usr/local/bin/dropbox", line 674, in send_command
    ok = self.__readline() == "ok"
  File "/usr/local/bin/dropbox", line 648, in __readline
    raise DropboxCommand.BadConnectionError()
__main__.BadConnectionError
```