### PR TITLE
build: handle (in some way) the new GNOME versioning scheme

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,11 @@ NAUTILUS_VERSION=`$PKG_CONFIG --modversion libnautilus-extension`
 if test -n "$NAUTILUS_VERSION"; then
     NAUTILUS_VERSION_MAJOR=`echo -n $NAUTILUS_VERSION | cut -d . -f 1`
     NAUTILUS_VERSION_MINOR=`echo -n $NAUTILUS_VERSION | cut -d . -f 2`
+    case "$NAUTILUS_VERSION_MINOR" in
+      *[[a-zA-Z]]* )
+          NAUTILUS_VERSION_MINOR=0
+          ;;
+    esac
     NAUTILUS_VERSION_MICRO=`echo -n $NAUTILUS_VERSION | cut -d . -f 3`
 fi
 


### PR DESCRIPTION
With GNOME switching from odd/even versioning for unsstable/stable
branches to 40.alpha, 40.beta, we need to trick the versioning to
our liking.

In case NAUTILUS_VERSION_MINOR contains letters, we reset it to 0.

This means we treat 40.alpha as 40.0 (as if it was the final release of the 40 series)

Fixes #97
