### PR TITLE
Fix the deprecation warning for call to `isSet()`

### DIFF
--- a/dropbox.in
+++ b/dropbox.in
@@ -611,7 +611,7 @@ class CommandTicker(threading.Thread):
         first = True
         while True:
             self.stop_event.wait(0.25)
-            if self.stop_event.isSet(): break
+            if self.stop_event.is_set(): break
             if i == len(ticks):
                 first = False
                 i = 0


### PR DESCRIPTION
Running the command `dropbox status` prints the following warning message:
```
/usr/bin/dropbox:614: DeprecationWarning: isSet() is deprecated, use is_set() instead
  if self.stop_event.isSet(): break
```
because of the use of the deprecated `isSet()` function call from `threading.Event`.

This commit uses the new `is_set()`, which [is available since Python 2.6](https://docs.python.org/2.7/library/threading.html#event-objects).
