### PR TITLE
[dropbox.in] Switch to threading.Event.is_set()

### DIFF
--- a/dropbox.in
+++ b/dropbox.in
@@ -611,7 +611,7 @@ class CommandTicker(threading.Thread):
         first = True
         while True:
             self.stop_event.wait(0.25)
-            if self.stop_event.isSet(): break
+            if self.stop_event.is_set(): break
             if i == len(ticks):
                 first = False
                 i = 0


### PR DESCRIPTION
The following warning is printed on multiple dropbox subcommands:
```
  % dropbox filestatus ./*
  /usr/bin/dropbox:614: DeprecationWarning: isSet() is deprecated, use is_set() instead
    if self.stop_event.isSet(): break
```
Fix it by switching from deprecated `isSet()` to `is_set()`.

Documentation for all Python 3.x versions available on python.org
mentions `is_set()` for `threading.Event`, see e.g. [0] for the oldest
available 3.5.

[0] https://docs.python.org/3.5/library/threading.html#threading.Event

Signed-off-by: Andrey Ignatov <rdna@rdna.ru>