### PR TITLE
Update .deb packaging to run on Ubuntu 22.10.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,5 +29,6 @@ src/libnautilus_dropbox_la*
 rpmbuild/
 mockout/
 nautilus-dropbox-*.tar.bz2
+nautilus-dropbox-*.*.*/
 .mypy_cache/
 .vscode/

--- a/.pbuilderrc
+++ b/.pbuilderrc
@@ -2,14 +2,14 @@
 
 # Codenames for Debian suites according to their alias. Update these when
 # needed.
-STABLE_CODENAME="stretch"
+STABLE_CODENAME="bullseye"
 STABLE_BACKPORTS_SUITE="$STABLE_CODENAME-backports"
 
 # List of Debian suites.
-DEBIAN_SUITES=("jessie")
+DEBIAN_SUITES=("bookworm")
 
 # List of Ubuntu suites. Update these when needed.
-UBUNTU_SUITES=("trusty")
+UBUNTU_SUITES=("kinetic")
 
 # Mirrors to use. Update these to your preferred mirror.
 DEBIAN_MIRROR="ftp.us.debian.org"

--- a/HOWTO_PACKAGE.md
+++ b/HOWTO_PACKAGE.md
@@ -15,15 +15,14 @@ an Ubuntu 22.10 machine for the `.deb` build and a Fedora 37 machine for the `.r
       sudo apt-get install pbuilder debootstrap devscripts libnautilus-extension-dev cdbs gnome-common debian-archive-keyring python3-docutils
       ```
 
-   2. Copy `.pbuilderrc` to `~/.pbuilderrc`
+   2. Copy `.pbuilderrc` to `/root/.pbuilderrc`
 
    3. Create chroots for each of the Debian or Ubuntu builds you'll be doing.
 
    ```
-   sudo DIST=trusty ARCH=i386 pbuilder create --debootstrapopts --variant=buildd
-   sudo DIST=trusty ARCH=amd64 pbuilder create --debootstrapopts --variant=buildd
-   sudo DIST=jessie ARCH=i386 pbuilder create --debootstrapopts --variant=buildd
-   sudo DIST=jessie ARCH=amd64 pbuilder create --debootstrapopts --variant=buildd
+   sudo DIST=kinetic ARCH=amd64 pbuilder create --debootstrapopts --variant=buildd
+   sudo DIST=bookworm ARCH=i386 pbuilder create --debootstrapopts --variant=buildd
+   sudo DIST=bookworm ARCH=amd64 pbuilder create --debootstrapopts --variant=buildd
    ```
 
    4. Build all the packages with: `python3 build_packages.py deb`

--- a/build_packages.py
+++ b/build_packages.py
@@ -52,7 +52,9 @@ class BuildController:
             assert self.system('sudo rm -rf /var/cache/pbuilder/%s-%s/result/*' % (dist, arch)) == 0
             assert self.system('DIST=%s ARCH=%s pdebuild' % (dist, arch)) == 0
             # auto-sign doesn't work on i386 in this version of pdebuild.  So we sign in a separate step.
-            assert self.system('debsign -k5044912E /var/cache/pbuilder/%s-%s/result/*.changes' % (dist, arch)) == 0
+            # We also have to use the long key ID here instead of the short one (like we do in Fedora),
+            # since debsign no longer accepts short key IDs.
+            assert self.system('debsign -k FC918B335044912E /var/cache/pbuilder/%s-%s/result/*.changes' % (dist, arch)) == 0
         finally:
             os.chdir('../..')
 
@@ -160,14 +162,13 @@ class BuildController:
 
         if len(sys.argv) == 1 or 'deb' in sys.argv:
             # Ubuntu
-            self.build_deb('trusty', 'i386')
-            self.build_deb('trusty', 'amd64')
-            self.generate_deb_repo('Ubuntu', info['UBUNTU_CODENAMES'], 'trusty', ['amd64', 'i386'])
+            self.build_deb('kinetic', 'amd64')
+            self.generate_deb_repo('Ubuntu', info['UBUNTU_CODENAMES'], 'kinetic', ['amd64'])
 
             # Debian
-            self.build_deb('jessie', 'i386')
-            self.build_deb('jessie', 'amd64')
-            self.generate_deb_repo('Debian', info['DEBIAN_CODENAMES'], 'jessie', ['amd64', 'i386'])
+            self.build_deb('bookworm', 'i386')
+            self.build_deb('bookworm', 'amd64')
+            self.generate_deb_repo('Debian', info['DEBIAN_CODENAMES'], 'bookworm', ['amd64', 'i386'])
 
         # Fedora
         if len(sys.argv) == 1 or 'rpm' in sys.argv:

--- a/configure.ac
+++ b/configure.ac
@@ -24,7 +24,7 @@ PKG_PROG_PKG_CONFIG
 
 PKG_CHECK_MODULES(NAUTILUS, libnautilus-extension-4 >= $NAUTILUS_REQUIRED)
 PKG_CHECK_MODULES(GLIB, glib-2.0 >= $GLIB_REQUIRED)
-PKG_CHECK_MODULES(GTK, gtk4 >= 4.6.0)
+PKG_CHECK_MODULES(GTK, gtk4)
 
 AC_SUBST(GTK_CFLAGS)
 
@@ -112,7 +112,7 @@ EMBLEM_DIR='${datadir}/nautilus-dropbox/emblems'
 AC_SUBST(EMBLEM_DIR)
 
 AC_CONFIG_FILES([
-	Makefile 
+	Makefile
 	src/Makefile
 	data/Makefile
 	data/icons/Makefile

--- a/distro-info.sh
+++ b/distro-info.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 # This file also gets execfile'd by python so don't do anything here besides set variables.
-UBUNTU_CODENAMES="trusty utopic vivid wily xenial yakkety zesty artful bionic cosmic disco eoan"
-DEBIAN_CODENAMES="jessie stretch buster sid"
-FEDORA_CODENAMES="21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37"
+UBUNTU_CODENAMES="kinetic"
+DEBIAN_CODENAMES="bookworm sid"
+FEDORA_CODENAMES="37"

--- a/generate-deb.sh
+++ b/generate-deb.sh
@@ -46,19 +46,6 @@ include /usr/share/cdbs/1/class/autotools.mk
 
 # Avoid postinst-has-useless-call-to-ldconfig and pkg-has-shlibs-control-file-but-no-actual-shared-libs
 DEB_DH_MAKESHLIBS_ARGS=-Xnautilus-dropbox
-
-debian/tmp/usr/lib/nautilus/extensions-2.0/libnautilus-dropbox.so:
-	mkdir -p debian/tmp/usr/lib/nautilus/extensions-2.0
-	ln -s ../extensions-3.0/libnautilus-dropbox.so debian/tmp/usr/lib/nautilus/extensions-2.0/
-
-debian/tmp/usr/lib/nautilus/extensions-3.0/libnautilus-dropbox.so:
-	mkdir -p debian/tmp/usr/lib/nautilus/extensions-3.0
-	ln -s ../extensions-2.0/libnautilus-dropbox.so debian/tmp/usr/lib/nautilus/extensions-3.0/
-
-install/dropbox:: debian/tmp/usr/lib/nautilus/extensions-3.0/libnautilus-dropbox.so  debian/tmp/usr/lib/nautilus/extensions-2.0/libnautilus-dropbox.so
-	rm debian/tmp/usr/lib/nautilus/extensions-?.0/*.la
-	rm debian/tmp/usr/lib/nautilus/extensions-?.0/*.a
-
 EOF
 chmod a+x debian/rules
 
@@ -76,7 +63,7 @@ $(date -R).
 
 It was downloaded from https://www.dropbox.com/download?dl=packages/nautilus-dropbox-$CURVER.tar.bz2
 
-Copyright: 
+Copyright:
 
   Copyright Dropbox, Inc.
 
@@ -410,7 +397,7 @@ rm -rf /var/lib/update-notifier/user.d/dropbox-start-required
 exit 0
 EOF
 
-echo "6" > debian/compat
+echo "10" > debian/compat
 
 cat > debian/dropbox.install <<EOF
 debian/tmp/usr/*
@@ -430,7 +417,7 @@ Source: dropbox
 Section: gnome
 Priority: optional
 Maintainer: Dropbox <support@dropbox.com>
-Build-Depends: cdbs, debhelper (>= 9), build-essential, libnautilus-extension-dev (>= 3.10.1), libglib2.0-dev (>= 2.40), python3-docutils, python3-gi (>= 3.12)
+Build-Depends: cdbs, debhelper (>= 10), build-essential, libnautilus-extension-dev (>= 43.0), libgtk-4-dev (>= 4.8), libglib2.0-dev (>= 2.40), python3-docutils, python3-gi (>= 3.12)
 Standards-Version: 3.9.4.0
 
 Package: dropbox
@@ -438,8 +425,8 @@ Replaces: nautilus-dropbox
 Breaks: nautilus-dropbox
 Provides: nautilus-dropbox
 Architecture: any
-Depends: procps, python3-gi (>= 3.12), python3 (>= 3.4.0), \${python3:Depends}, \${misc:Depends}, libatk1.0-0 (>= 2.10), libc6 (>= 2.19), libcairo2 (>= 1.13), libglib2.0-0 (>= 2.40), libgtk-3-0 (>= 3.10.8), libpango1.0-0 (>= 1.36.3), lsb-release, gir1.2-gdkpixbuf-2.0 (>= 2.30.7), gir1.2-glib-2.0 (>= 1.40.0), gir1.2-gtk-3.0 (>= 3.10.8), gir1.2-pango-1.0 (>= 1.36.3)
-Suggests: nautilus (>= 3.10.1), python3-gpg (>= 1.8.0)
+Depends: procps, python3-gi (>= 3.12), python3 (>= 3.4.0), \${python3:Depends}, \${misc:Depends}, libatk1.0-0 (>= 2.10), libc6 (>= 2.19), libcairo2 (>= 1.13), libglib2.0-0 (>= 2.40), libgtk-4-1 (>= 4.8.0), libpango1.0-0 (>= 1.36.3), lsb-release, gir1.2-gdkpixbuf-2.0 (>= 2.30.7), gir1.2-glib-2.0 (>= 1.40.0), gir1.2-gtk-4.0 (>= 4.8.0), gir1.2-pango-1.0 (>= 1.36.3)
+Suggests: nautilus (>= 43.0), python3-gpg (>= 1.8.0)
 Homepage: https://www.dropbox.com/
 Description: cloud synchronization engine - CLI and Nautilus extension
  Dropbox is a free service that lets you bring your photos, docs, and videos


### PR DESCRIPTION
What it says on the tin.

Tested syncing and icons on both Ubuntu 22.10 and Fedora 37 (just in case).