### PR TITLE
Add tests to the canary job.

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -25,12 +25,26 @@ jobs:
         run: |
           . ./distro-info.sh
           . /etc/os-release
-          if [[ "$UBUNTU_CODENAMES" == *"$VERSION_CODENAME"* ]]; then
-            echo "$NAME $VERSION is supported."
-          else
-            echo "$NAME $VERSION needs to be added to distro-info.sh in order to produce the correct repo."
-            exit 1
-          fi
+          ./check-distro-info-support.sh "$VERSION_CODENAME" "$NAME $VERSION" "$UBUNTU_CODENAMES"
+
+  debian:
+    runs-on: ubuntu-latest
+    container:
+      image: debian:sid
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v3
+      - name: Install deps
+        run: apt-get update && apt-get install -y gnome-common libnautilus-extension-dev libgtk-4-dev python3-gi python3-docutils
+      - name: Test build
+        run: ./autogen.sh && make && make install
+      - name: Run tests
+        run: python3 ./dropbox_test.py
+      - name: Check that latest OS version is supported
+        run: |
+          . ./distro-info.sh
+          . /etc/os-release
+          ./check-distro-info-support.sh "$VERSION_CODENAME" "$PRETTY_NAME" "$DEBIAN_CODENAMES"
 
   fedora:
     runs-on: ubuntu-latest
@@ -49,9 +63,4 @@ jobs:
         run: |
           . ./distro-info.sh
           . /etc/os-release
-          if [[ "$FEDORA_CODENAMES" == *"$VERSION_ID"* ]]; then
-            echo "Fedora $VERSION_ID is supported."
-          else
-            echo "Fedora $VERSION_ID needs to be added to distro-info.sh in order to produce the correct repo."
-            exit 1
-          fi
+          ./check-distro-info-support.sh "$VERSION_ID" "Fedora $VERSION_ID" "$FEDORA_CODENAMES"

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,11 +1,11 @@
 name: Run canary builds
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
-    branches: [ master ]
+    branches: [master]
   schedule:
-    - cron: '29 1 * * 1'
+    - cron: "29 1 * * 1"
   workflow_dispatch:
 jobs:
   ubuntu:
@@ -19,6 +19,19 @@ jobs:
         run: apt-get update && apt-get install -y gnome-common libnautilus-extension-dev libgtk-4-dev python3-gi python3-docutils
       - name: Test build
         run: ./autogen.sh && make && make install
+      - name: Run tests
+        run: python3 ./dropbox_test.py
+      - name: Check that latest OS version is supported
+        run: |
+          . ./distro-info.sh
+          . /etc/os-release
+          if [[ "$UBUNTU_CODENAMES" == *"$VERSION_CODENAME"* ]]; then
+            echo "$NAME $VERSION is supported."
+          else
+            echo "$NAME $VERSION needs to be added to distro-info.sh in order to produce the correct repo."
+            exit 1
+          fi
+
   fedora:
     runs-on: ubuntu-latest
     container:
@@ -30,3 +43,15 @@ jobs:
         run: dnf install -y gnome-common nautilus-devel gtk4-devel python3-docutils python3-gobject
       - name: Test build
         run: ./autogen.sh && make && make install
+      - name: Run tests
+        run: python3 ./dropbox_test.py
+      - name: Check that latest OS version is supported
+        run: |
+          . ./distro-info.sh
+          . /etc/os-release
+          if [[ "$FEDORA_CODENAMES" == *"$VERSION_ID"* ]]; then
+            echo "Fedora $VERSION_ID is supported."
+          else
+            echo "Fedora $VERSION_ID needs to be added to distro-info.sh in order to produce the correct repo."
+            exit 1
+          fi

--- a/check-distro-info-support.sh
+++ b/check-distro-info-support.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -euo pipefail
+
+current_version_codename=$1
+current_version_display_name=$2
+supported_version_codenames=$3
+
+for supported_version in $supported_version_codenames; do
+    if [[ "$current_version_codename" == "$supported_version" ]]; then
+        printf "$current_version_display_name is supported."
+        exit 0
+    fi
+done
+
+printf "$current_version_display_name needs to be added to distro-info.sh in order to produce the correct repo."
+exit 1

--- a/distro-info.sh
+++ b/distro-info.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 # This file also gets execfile'd by python so don't do anything here besides set variables.
-UBUNTU_CODENAMES="kinetic"
+UBUNTU_CODENAMES="kinetic lunar"
 DEBIAN_CODENAMES="bookworm sid"
-FEDORA_CODENAMES="37"
+FEDORA_CODENAMES="37 38"

--- a/dropbox.in
+++ b/dropbox.in
@@ -753,7 +753,7 @@ def start_dropbox():
 
         # Fix indicator icon and menu on Unity environments. (LP: #1559249)
         # Fix indicator icon and menu in Budgie environment. (LP: #1683051)
-        new_env = os.environ.copy()        
+        new_env = os.environ.copy()
         current_env = os.environ.get("XDG_CURRENT_DESKTOP", '').split(":")
         to_check = ['Unity', 'Budgie']
         if any(word in to_check for word in current_env):


### PR DESCRIPTION
This adds not just the existing automated test suite, but also adds a new test to make sure that the latest versions of Ubuntu and Fedora are correctly included in the set of versions we support, since we use those values to generate the package repos.

I've left the supported versions list unchanged for the first iteration of this PR so that we can see the canary job fail, and I'll update them before merging.