### PR TITLE
Add Ubuntu 23.10 (Mantic Minotaur) to distro-info.sh

### DIFF
--- a/distro-info.sh
+++ b/distro-info.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 # This file also gets execfile'd by python so don't do anything here besides set variables.
-UBUNTU_CODENAMES="kinetic lunar"
+UBUNTU_CODENAMES="kinetic lunar mantic"
 DEBIAN_CODENAMES="bookworm sid"
 FEDORA_CODENAMES="37 38 39"


### PR DESCRIPTION
This will enable building of repos for Ubuntu Mantic, which releases in October 2023.