### PR TITLE
Fix symlinks in packages/$DISTRO

### DIFF
--- a/create-ubuntu-repo.sh
+++ b/create-ubuntu-repo.sh
@@ -62,5 +62,5 @@ rm -rf apt-release.conf apt-ftparchive.conf
 mkdir -p $SRCDIR/build/packages/$DISTRO
 for F in pool/main/*.deb; do
     echo Symlinking $F
-    ln -sf ../../$DISTRO/pool/main/$F $SRCDIR/build/packages/$DISTRO/
+    ln -sf ../../$DISTRO/$F $SRCDIR/build/packages/$DISTRO/
 done

--- a/create-yum-repo.sh
+++ b/create-yum-repo.sh
@@ -11,7 +11,7 @@ for DIST in $DISTS; do
   for ARCH in $ARCHS; do
     mkdir -p $DIST/$ARCH
     cd  $DIST/$ARCH
-    ln -s ../../pool/*$ARCH*.rpm .
+    ln -sf ../../pool/*$ARCH*.rpm .
     cd ../..
 
   done
@@ -19,5 +19,15 @@ for DIST in $DISTS; do
   createrepo $DIST
 done
 
+# Move up into build dir.
+cd ..
+
+# Create symlinks for packages.
+mkdir -p packages/fedora
+for F in fedora/pool/*.rpm; do
+    echo Symlinking $F
+    ln -sf ../../$F packages/fedora/
+done
+
 # Go back up to top-level directory to leave the caller in the same dir they started.
-cd ../..
+cd ..


### PR DESCRIPTION
We create symlinks in `packages/$DISTRO` that are linked to from https://dropbox.com/install-linux
In the automated CI build job these symlinks were being created to the incorrect place due to a bash scripting error.
This PR updates the script so that the symlinks correctly point to the packages in `pool`.