### PR TITLE
Flatten single-item submenus

### DIFF
--- a/src/nautilus-dropbox.c
+++ b/src/nautilus-dropbox.c
@@ -549,7 +549,6 @@ static int
 nautilus_dropbox_parse_menu(gchar			**options,
 			    NautilusMenu		*menu,
 			    GString			*old_action_string,
-			    GList			*toret,
 			    NautilusMenuProvider	*provider,
 			    GList			*files)
 {
@@ -585,7 +584,7 @@ nautilus_dropbox_parse_menu(gchar			**options,
       g_string_append(new_action_string, "::");
 
       ret += nautilus_dropbox_parse_menu(suboptions, submenu, new_action_string,
-					 toret, provider, files);
+					 provider, files);
 
       item = nautilus_menu_item_new(new_action_string->str,
 				    item_name, "", NULL);
@@ -738,7 +737,7 @@ nautilus_dropbox_get_file_items(NautilusMenuProvider *provider,
     GString *action_string = g_string_new("NautilusDropbox::");
 
     if (!nautilus_dropbox_parse_menu(options, root_menu, action_string,
-				     toret, provider, files)) {
+				     provider, files)) {
 	g_object_unref(toret);
 	toret = NULL;
     }

--- a/src/nautilus-dropbox.c
+++ b/src/nautilus-dropbox.c
@@ -728,21 +728,32 @@ nautilus_dropbox_get_file_items(NautilusMenuProvider *provider,
     /* build the menu */
     NautilusMenuItem *root_item;
     NautilusMenu *root_menu;
+    GList *submenu_items;
+    guint list_length;
 
     root_menu = nautilus_menu_new();
-    root_item = nautilus_menu_item_new("NautilusDropbox::root_item",
-				       "Dropbox", "Dropbox Options", "dropbox");
 
-    toret = g_list_append(toret, root_item);
     GString *action_string = g_string_new("NautilusDropbox::");
 
-    if (!nautilus_dropbox_parse_menu(options, root_menu, action_string,
-				     provider, files)) {
-	g_object_unref(toret);
-	toret = NULL;
-    }
+    nautilus_dropbox_parse_menu(options, root_menu, action_string,
+				provider, files);
 
-    nautilus_menu_item_set_submenu(root_item, root_menu);
+    submenu_items = nautilus_menu_get_items(root_menu);
+    list_length = g_list_length(submenu_items);
+
+    if (list_length == 1) {
+      /* Return only the single menu item */
+      toret = submenu_items;
+    } else {
+      /* Construct a Dropbox submenu */
+      root_item = nautilus_menu_item_new("NautilusDropbox::root_item",
+					 "Dropbox", "Dropbox Options",
+					 "dropbox");
+      nautilus_menu_item_set_submenu(root_item, root_menu);
+      toret = g_list_append(toret, root_item);
+
+      g_list_free_full(submenu_items, g_object_unref);
+    }
 
     g_string_free(action_string, TRUE);
     g_object_unref(root_menu);


### PR DESCRIPTION
Nautilus since v43 uses Gtk4 for its file views, and the context menus are implemented as popovers instead of "real" traditional context menus. One functionality difference is, submenus don't open on hover, they have to be clicked to enter.

That makes single-item submenus particularly tedious to deal with. When right-clicking on a file/directory that's **not** in the Dropbox folder, the only item displayed is "Move to Dropbox", and having it hidden in a submenu is an unnecessary complication.

These patches detect when the Dropbox submenu contains only a single item, and promotes it to the top level, removing the extra indirection to reach it.

Dropbox submenus containing two or more items are unaffected.

A preparatory commit removes the `toret` argument from the `nautilus_dropbox_parse_menu()` function, a necessary adjustment because `toret` (which was unused in the function anyway) will no longer be defined until after `nautilus_dropbox_parse_menu()` is called.

Then, the second commit makes the adjustments so that `nautilus_dropbox_get_file_items()` calls `nautilus_dropbox_parse_menu()` **before** setting up its outer menu wrapper. Then, based on whether the list of menu items returned contains 1 or more than one items, it will either return the single item as its menu option, or create a "Dropbox" wrapper and place the list of multiple items into it as a submenu, as before.

### Without this patch

![image](https://github.com/dropbox/nautilus-dropbox/assets/538020/e58bd0c7-1219-4c90-8770-61fbac2274b9)

![image](https://github.com/dropbox/nautilus-dropbox/assets/538020/caa71bae-8818-46cb-afc4-e27bd1386823)

### With this patch

![image](https://github.com/dropbox/nautilus-dropbox/assets/538020/ea34c330-e0ec-4a16-8383-7d8e850c34a0)
