### PR TITLE
Update libpango name for Noble Numbat and Debian 12.

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 # TODO: update this to 24.04 once it's released. Ideally this should _always_
 # be the latest LTS release, but an interim release is used here because Jammy
 # doesn't have the minimum version of GNOME necessary to build the extension.
-FROM ubuntu:mantic
+FROM ubuntu:noble
 
 COPY install-apt-deps.sh .
 RUN ./install-apt-deps.sh

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,6 +1,3 @@
-# TODO: update this to 24.04 once it's released. Ideally this should _always_
-# be the latest LTS release, but an interim release is used here because Jammy
-# doesn't have the minimum version of GNOME necessary to build the extension.
 FROM ubuntu:noble
 
 COPY install-apt-deps.sh .

--- a/generate-deb.sh
+++ b/generate-deb.sh
@@ -424,7 +424,7 @@ Replaces: nautilus-dropbox
 Breaks: nautilus-dropbox
 Provides: nautilus-dropbox
 Architecture: any
-Depends: procps, python3-gi (>= 3.12), python3 (>= 3.4.0), \${python3:Depends}, \${misc:Depends}, libatk1.0-0 (>= 2.10), libc6 (>= 2.19), libcairo2 (>= 1.13), libglib2.0-0 (>= 2.40), libgtk-4-1 (>= 4.8.0), libpango1.0-0 (>= 1.36.3) | libpango-1.0.0 (>= 1.36.3), lsb-release, gir1.2-gdkpixbuf-2.0 (>= 2.30.7), gir1.2-glib-2.0 (>= 1.40.0), gir1.2-gtk-4.0 (>= 4.8.0), gir1.2-pango-1.0 (>= 1.36.3)
+Depends: procps, python3-gi (>= 3.12), python3 (>= 3.4.0), \${python3:Depends}, \${misc:Depends}, libatk1.0-0 (>= 2.10), libc6 (>= 2.19), libcairo2 (>= 1.13), libglib2.0-0 (>= 2.40), libgtk-4-1 (>= 4.8.0), libpango1.0-0 (>= 1.36.3) | libpango-1.0-0 (>= 1.36.3), lsb-release, gir1.2-gdkpixbuf-2.0 (>= 2.30.7), gir1.2-glib-2.0 (>= 1.40.0), gir1.2-gtk-4.0 (>= 4.8.0), gir1.2-pango-1.0 (>= 1.36.3)
 Suggests: nautilus (>= 43.0), python3-gpg (>= 1.8.0)
 Homepage: https://www.dropbox.com/
 Description: cloud synchronization engine - CLI and Nautilus extension

--- a/generate-deb.sh
+++ b/generate-deb.sh
@@ -424,7 +424,7 @@ Replaces: nautilus-dropbox
 Breaks: nautilus-dropbox
 Provides: nautilus-dropbox
 Architecture: any
-Depends: procps, python3-gi (>= 3.12), python3 (>= 3.4.0), \${python3:Depends}, \${misc:Depends}, libatk1.0-0 (>= 2.10), libc6 (>= 2.19), libcairo2 (>= 1.13), libglib2.0-0 (>= 2.40), libgtk-4-1 (>= 4.8.0), libpango1.0-0 (>= 1.36.3), lsb-release, gir1.2-gdkpixbuf-2.0 (>= 2.30.7), gir1.2-glib-2.0 (>= 1.40.0), gir1.2-gtk-4.0 (>= 4.8.0), gir1.2-pango-1.0 (>= 1.36.3)
+Depends: procps, python3-gi (>= 3.12), python3 (>= 3.4.0), \${python3:Depends}, \${misc:Depends}, libatk1.0-0 (>= 2.10), libc6 (>= 2.19), libcairo2 (>= 1.13), libglib2.0-0 (>= 2.40), libgtk-4-1 (>= 4.8.0), libpango1.0-0 (>= 1.36.3) | libpango-1.0.0 (>= 1.36.3), lsb-release, gir1.2-gdkpixbuf-2.0 (>= 2.30.7), gir1.2-glib-2.0 (>= 1.40.0), gir1.2-gtk-4.0 (>= 4.8.0), gir1.2-pango-1.0 (>= 1.36.3)
 Suggests: nautilus (>= 43.0), python3-gpg (>= 1.8.0)
 Homepage: https://www.dropbox.com/
 Description: cloud synchronization engine - CLI and Nautilus extension


### PR DESCRIPTION
## Summary
The `libpango` package was renamed in these releases, so use the alternate package name support for `.deb` packages as covered in https://www.debian.org/doc/debian-policy/ch-relationships.html.

Fixes #141, #95

## Test plan
Create new packages using `./build_packages.sh`, then install them into Noble and Bookworm containers using `apt --fix-broken install <debpath>`.