### PR TITLE
Remove 32bit support from nautilus-dropbox

### DIFF
--- a/dropbox.in
+++ b/dropbox.in
@@ -121,11 +121,7 @@ def yes_no_question(question):
 def plat():
     if sys.platform.lower().startswith('linux'):
         arch = platform.machine()
-        if (arch[0] == 'i' and
-            arch[1].isdigit() and
-            arch[2:4] == '86'):
-            plat = "x86"
-        elif arch == 'x86_64':
+        if arch == 'x86_64':
             plat = arch
         else:
             FatalVisibleError("Platform not supported")


### PR DESCRIPTION
Dropbox does not support 32bit on Linux anymore. Update platform check so that 32 bit os's fall into the unsupported case.
