### PR TITLE
Add box64 wrapper to enable running Dropbox source builds on ARM64 Ubuntu.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,28 +26,48 @@ Dropbox Nautilus yourself if you need a package for a distribution
 that we don't support, or you want to develop on the Dropbox Nautilus
 package.
 
+### Dependencies
+
 You will need to install the following dependencies:
 
-For Ubuntu:
+#### Ubuntu
 
 ```
 $ sudo apt-get install -y gnome-common libgtk-4-dev libnautilus-extension-dev python3-gi python3-docutils
 ```
 
-For Fedora:
+If you're running on an ARM machine, you'll also have to run the following:
+
+```
+$ sudo apt-get install -y box64
+```
+
+> [!CAUTION]
+> Note that ARM support is **_NO EFFORT ONLY_**. The tray icon doesn't work, we don't produce first-party packages for it, and other things might break in the future. This is just to make it a bit easier to install on SBCs or use in VMs hosted on Apple Silicon machines.
+>
+> IF YOU FILE AN ISSUE FOR THE ARM VERSION WE WILL CLOSE IT!
+
+#### Fedora
 
 ```
 $ sudo dnf install -y gnome-common nautilus-devel gtk4-devel python3-docutils
 ```
 
+Due to difficulties with programmatically managing multiarch library installations in Fedora without breaking nonstandard setups, we don't even pretend to have an ARM version.
+
+### Building and installing
+
 Then run the following to build and install nautilus-dropbox:
+
 ```
 $ ./autogen.sh
 $ make
 $ sudo make install
 ```
 
-This creates a "binary" named "dropbox" in the repo.
+This creates a "binary" named `dropbox` in the repo.
+
+### Running
 
 To start out the installer GUI, make sure the Dropbox desktop client
 isn't currently installed and run:
@@ -55,7 +75,6 @@ isn't currently installed and run:
 ```
 $ ./dropbox start -i
 ```
-
 
 After installing the package you may run into issues unless you
 restart Nautilus. You can do that by issuing the following command
@@ -66,6 +85,6 @@ log out and log back in instead):
 $ killall nautilus
 ```
 
-## Creating a .deb or .rpm package
+## Creating a `.deb` or `.rpm` package
 
 See [HOWTO_PACKAGE.md](HOWTO_PACKAGE.md)

--- a/dropbox.in
+++ b/dropbox.in
@@ -122,13 +122,23 @@ def yes_no_question(question):
 def plat():
     if sys.platform.lower().startswith('linux'):
         arch = platform.machine()
-        if arch == 'x86_64':
-            plat = arch
+        if arch in ('x86_64', 'aarch64'):
+            return "lnx.x86_64"  # This is a cool trick called "lying."
         else:
-            FatalVisibleError("Platform not supported")
-        return "lnx.%s" % plat
+            FatalVisibleError("CPU architecture not supported")
     else:
-        FatalVisibleError("Platform not supported")
+        FatalVisibleError("Operating system not supported")
+
+def dropbox_cmd():
+    arch = platform.machine()
+    if arch == 'x86_64':
+        return [DROPBOXD_PATH]
+    elif arch == 'aarch64':
+        box64_path = shutil.which('box64')
+        assert box64_path, "Unable to find box64 executable. To run Dropbox under ARM, please make sure box64 is on your path!"
+        return [box64_path, DROPBOXD_PATH]
+    else:
+        FatalVisibleError("CPU architecture not supported")
 
 def is_dropbox_running():
     pidfile = os.path.expanduser("~/.dropbox/dropbox.pid")
@@ -138,7 +148,7 @@ def is_dropbox_running():
             pid = int(f.read())
         with open("/proc/%d/cmdline" % pid, "r") as f:
             cmdline = f.read().lower()
-    except:
+    except Exception:
         cmdline = ""
 
     return "dropbox" in cmdline
@@ -257,7 +267,7 @@ class DownloadState(object):
         """
         f = open("/dev/null", "w")
         try:
-            a = subprocess.Popen([DROPBOXD_PATH, "/testrun", "0"], preexec_fn=os.setsid, cwd=os.path.expanduser("~"),
+            a = subprocess.Popen(dropbox_cmd() + ["/testrun", "0"], preexec_fn=os.setsid, cwd=os.path.expanduser("~"),
                                  stderr=sys.stderr, stdout=f, close_fds=True)
         except Exception as e:
             print(e)
@@ -774,7 +784,7 @@ def start_dropbox():
             new_env['XDG_CURRENT_DESKTOP'] = 'Unity'
 
         # we don't reap the child because we're gonna die anyway, let init do it
-        subprocess.Popen([DROPBOXD_PATH], preexec_fn=os.setsid, cwd=os.path.expanduser("~"),
+        subprocess.Popen(dropbox_cmd(), preexec_fn=os.setsid, cwd=os.path.expanduser("~"),
                              stderr=sys.stderr, stdout=f, close_fds=True, env=new_env)
 
         # in seconds

--- a/install-apt-deps.sh
+++ b/install-apt-deps.sh
@@ -3,3 +3,8 @@
 apt-get update
 apt-get install -y gnome-common libgtk-4-dev libnautilus-extension-dev python3-gi python3-docutils \
     debootstrap devscripts libnautilus-extension-dev cdbs debian-archive-keyring debhelper
+
+if [[ "$(uname -p)" == "aarch64" ]]
+then
+    apt-get install box64
+fi


### PR DESCRIPTION
1. This is purely for making it a bit easier to run on SBC machines and Apple Silicon VMs. This is not a serious build.
2. The tray icon doesn't work and we're not going to produce an official package. Source builds only.
3. Due to multiarch package difficulties, ARM64 Fedora is 100% unsupported, unlike ARM64 Ubuntu, which is 99% unsupported.
4. A native ARM build is unlikely any time soon.

Within the above constraints, have fun!