### PR TITLE
Update deps for later Debian/Ubuntu versions.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 Date based versioning is now used in this project. This is so that it doesn't get confused with the Dropbox desktop client.
 
+## Version 2026.05.06
+
+- Put build-only packages behind a flag on Debian/Ubuntu.
+- Updated Debian/Ubuntu dependencies to handle some packages that have been renamed.
+
 ## Version 2026.03.20
 
 - Add Fedora 45 to build matrix.

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,5 +1,5 @@
 FROM debian:bookworm
 
 COPY install-apt-deps.sh .
-RUN ./install-apt-deps.sh
+RUN DBX_BUILD_ENV=packaging ./install-apt-deps.sh
 WORKDIR /src

--- a/Dockerfile.debian_i386
+++ b/Dockerfile.debian_i386
@@ -1,5 +1,5 @@
 FROM i386/debian:bookworm
 
 COPY install-apt-deps.sh .
-RUN ./install-apt-deps.sh
+RUN DBX_BUILD_ENV=packaging ./install-apt-deps.sh
 WORKDIR /src

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
 FROM ubuntu:noble
 
 COPY install-apt-deps.sh .
-RUN ./install-apt-deps.sh
+RUN DBX_BUILD_ENV=packaging ./install-apt-deps.sh
 WORKDIR /src

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Initialization
 
-AC_INIT([nautilus-dropbox], 2026.03.20)
+AC_INIT([nautilus-dropbox], 2026.05.06)
 
 AM_INIT_AUTOMAKE([foreign])
 

--- a/generate-deb.sh
+++ b/generate-deb.sh
@@ -432,7 +432,7 @@ Replaces: nautilus-dropbox
 Breaks: nautilus-dropbox
 Provides: nautilus-dropbox
 Architecture: any
-Depends: procps, python3-gi (>= 3.12), python3 (>= 3.4.0), \${python3:Depends}, \${misc:Depends}, libatk1.0-0 (>= 2.10), libc6 (>= 2.19), libcairo2 (>= 1.13), libglib2.0-0 (>= 2.40), libgtk-4-1 (>= 4.8.0), libpango1.0-0 (>= 1.36.3) | libpango-1.0-0 (>= 1.36.3), lsb-release, gir1.2-gdkpixbuf-2.0 (>= 2.30.7), gir1.2-glib-2.0 (>= 1.40.0), gir1.2-gtk-4.0 (>= 4.8.0), gir1.2-pango-1.0 (>= 1.36.3)
+Depends: procps, python3-gi (>= 3.12), python3 (>= 3.4.0), \${python3:Depends}, \${misc:Depends}, libatk1.0-0 (>= 2.10) | libatk1.0-0t64 (>= 2.52), libc6 (>= 2.19), libcairo2 (>= 1.13), libglib2.0-0 (>= 2.40) | libglib2.0-0t64 (>= 2.80), libgtk-4-1 (>= 4.8.0), libpango1.0-0 (>= 1.36.3) | libpango-1.0-0 (>= 1.36.3), lsb-release, gir1.2-gdkpixbuf-2.0 (>= 2.30.7), gir1.2-glib-2.0 (>= 1.40.0), gir1.2-gtk-4.0 (>= 4.8.0), gir1.2-pango-1.0 (>= 1.36.3)
 Suggests: nautilus (>= 43.0), python3-gpg (>= 1.8.0)
 Homepage: https://www.dropbox.com/
 Description: cloud synchronization engine - CLI and Nautilus extension

--- a/install-apt-deps.sh
+++ b/install-apt-deps.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
 apt-get update
-apt-get install -y gnome-common libgtk-4-dev libnautilus-extension-dev python3-gi python3-docutils \
-    debootstrap devscripts libnautilus-extension-dev cdbs debian-archive-keyring debhelper
+apt-get install -fy \
+    debhelper \
+    debian-archive-keyring \
+    debootstrap \
+    devscripts \
+    gnome-common \
+    libgtk-4-dev \
+    libnautilus-extension-dev \
+    libnautilus-extension-dev \
+    python3-docutils \
+    python3-gi
+
+case "${DBX_BUILD_ENV:=local}" in
+    packaging)
+        apt-get install -fy cdbs
+        ;;
+
+    *)
+        ;;
+esac

--- a/install-rpm-deps.sh
+++ b/install-rpm-deps.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
 
-dnf install -y --skip-unavailable gnome-common nautilus-devel gtk4-devel python3-docutils \
-    python3-gobject devscripts mock rpm rpm-sign rpmdevtools rpmlint expect createrepo cdbs \
-    gnome-common python3-docutils rpm-build gawk which atk-devel
+dnf install -y --skip-unavailable \
+    atk-devel \
+    cdbs \
+    createrepo \
+    devscripts \
+    expect \
+    gawk \
+    gnome-common \
+    gnome-common \
+    gtk4-devel \
+    mock \
+    nautilus-devel \
+    python3-docutils \
+    python3-docutils \
+    python3-gobject \
+    rpm \
+    rpm-build \
+    rpm-sign \
+    rpmdevtools \
+    rpmlint \
+    which


### PR DESCRIPTION
Two major changes here:

- Pulls out `cdbs` (which isn't included in current Debian versions) into a separate list of packages that are only installed during package building, which we do on our own machines instead of on client machines.
- Handles some renamed packages. I've been unable to repro that issue on VMs or Docker images, so hopefully it'll work!

As a minor change, I also reformatted the package lists to make it easier to track changes to the installed packages.