### PR TITLE
Add Ubuntu 26.10 Stonking Stingray to supported versions.

### DIFF
--- a/distro-info.sh
+++ b/distro-info.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 # This file also gets execfile'd by python so don't do anything here besides set variables.
-UBUNTU_CODENAMES="kinetic lunar mantic noble oracular plucky questing resolute"
+UBUNTU_CODENAMES="kinetic lunar mantic noble oracular plucky questing resolute stonking"
 DEBIAN_CODENAMES="bookworm trixie forky sid"
 FEDORA_CODENAMES="37 38 39 40 41 42 43 44 45"


### PR DESCRIPTION
I've decided not to bump the app version because we only really use the supported distros list when determining which distros to create repos for, and it's not read in the client itself.