### PR TITLE
Updated packaging to be a little more reliable when running locally.

### DIFF
--- a/build_packages.sh
+++ b/build_packages.sh
@@ -6,7 +6,7 @@ rm -rf build
 
 # Build deb packages.
 for DISTRO in ubuntu debian debian_i386; do
-    docker build -t nautilus-dropbox/$DISTRO -f Dockerfile.$DISTRO .
+    docker build --pull -t nautilus-dropbox/$DISTRO -f Dockerfile.$DISTRO .
     docker run -u "$(id -u):$(id -g)" -v `pwd`:/src nautilus-dropbox/$DISTRO ./generate-deb.sh
 done
 

--- a/generate-deb.sh
+++ b/generate-deb.sh
@@ -14,6 +14,8 @@ trap "rm -rf $TMPDIR" EXIT
 cp -R $SRCDIR/* $TMPDIR/
 cd $TMPDIR
 
+autoreconf -f -i
+
 # get version
 CURVER=$(mawk '/^AC_INIT/{sub("AC_INIT\(\[nautilus-dropbox\], ", ""); sub("\)", ""); print $0}' configure.ac)
 

--- a/install-apt-deps.sh
+++ b/install-apt-deps.sh
@@ -15,7 +15,7 @@ apt-get install -fy \
 
 case "${DBX_BUILD_ENV:=local}" in
     packaging)
-        apt-get install -fy cdbs
+        apt-get install -fy cdbs autotools-dev automake
         ;;
 
     *)


### PR DESCRIPTION
There's a weird interaction between Autotools and Docker here, so just make it very explicit that we're installing Autotools and also refresh the project before building.